### PR TITLE
Add ability to use img in button icon

### DIFF
--- a/wetmap/src/components/reusables/buttonIcon/style.module.scss
+++ b/wetmap/src/components/reusables/buttonIcon/style.module.scss
@@ -22,7 +22,8 @@
 .icon {
 	display: contents;
 
-	svg {
+	svg,
+	img {
 		height: 100%;
 	}
 }

--- a/wetmap/src/icons/Icon.tsx
+++ b/wetmap/src/icons/Icon.tsx
@@ -5,12 +5,8 @@ type IconName = keyof typeof config;
 
 type Props = {
   name:       IconName
-  className?: string
 };
 type viewBoxEncoded = string | number | null | Array<number>;
-type Config = {
-  [k in IconName]: [viewBoxEncoded, string]
-};
 
 const getFigure = (content: string): ReactElement | null => {
   if (!content) {
@@ -19,8 +15,7 @@ const getFigure = (content: string): ReactElement | null => {
 
   if (content.startsWith('<')) {
     return <g dangerouslySetInnerHTML={{ __html: content }}></g>;
-  }
-  else {
+  } else {
     return <path d={content}></path>;
   }
 };
@@ -55,7 +50,7 @@ const getViewBox = (data: viewBoxEncoded): string => {
 };
 
 
-const Icon = (props: Props) => {
+const Icon = (props: Props & React.SVGAttributes<SVGElement>) => {
   if (!config) {
     console.error(`_config.json not found. Run "_build-svg.js" generate config.`);
     return <></>;
@@ -74,7 +69,7 @@ const Icon = (props: Props) => {
   }
 
   const viewBox = getViewBox(config[iconName][0]);
-  const figure = getFigure(config[iconName][1]);
+  const figure = getFigure(String(config[iconName][1]));
   if (!figure) {
     console.error(`icon "${iconName}" is empty in _config.json. Config might be corrupted or svg file is invalid.`);
     return <></>;


### PR DESCRIPTION
Add ability to use `img` tag as an icon in buttonIcon component. 
Before, it was only working with svg icons and if we try to use `img` the layout didn't look good: the image appeared in its original size.
Now the size of the button with icon is controlled by classes  `btn-lg` and `btn-sm`
Also fixed small issues with types in Icon component (removed unused and added standard svg attributes to allowed props - such as "fill")