### PR TITLE
Web 49: BUG FIX - dive trip map view zoom

### DIFF
--- a/wetmap/src/components/MapPage.jsx
+++ b/wetmap/src/components/MapPage.jsx
@@ -70,6 +70,7 @@ const MapPage = React.memo(function MapPage() {
 
   const onShopNavigate = () => {
     setMapCoords([selectedShop.lat, selectedShop.lng]);
+    setMapZoom(16);
     setMapConfig(0);
     setSitesArray([]);
   };

--- a/wetmap/src/components/itineraries/itinerary.jsx
+++ b/wetmap/src/components/itineraries/itinerary.jsx
@@ -3,6 +3,7 @@ import { animated, useSpring } from 'react-spring';
 import { SitesArrayContext } from '../contexts/sitesArrayContext';
 import { CoordsContext } from '../contexts/mapCoordsContext';
 import { MapConfigContext } from '../contexts/mapConfigContext';
+import { ZoomContext } from '../contexts/mapZoomContext';
 import { ModalContext } from '../reusables/modal/context';
 import { getDiveSitesByIDs } from '../../supabaseCalls/diveSiteSupabaseCalls';
 import style from './style.module.scss';
@@ -11,8 +12,9 @@ import Icon from '../../icons/Icon';
 
 export default function Itinerary(props) {
   const { itinerary, selectedID, setSelectedID } = props;
-  const { sitesArray, setSitesArray } = useContext(SitesArrayContext);
-  const { mapCoords, setMapCoords } = useContext(CoordsContext);
+  const { setSitesArray } = useContext(SitesArrayContext);
+  const { setMapCoords } = useContext(CoordsContext);
+  const { setMapZoom } = useContext(ZoomContext);
   const { setMapConfig } = useContext(MapConfigContext);
   const modalContext = useContext(ModalContext);
 
@@ -56,6 +58,7 @@ export default function Itinerary(props) {
     });
     let moveLat = lats.reduce((acc, curr) => acc + curr, 0) / lats.length;
     let moveLng = lngs.reduce((acc, curr) => acc + curr, 0) / lngs.length;
+    setMapZoom(12);
     setMapConfig(2);
     setMapCoords([moveLat, moveLng]);
     modalContext.modalCancel();


### PR DESCRIPTION
Correcting issue that was causing the map to stay VERY zoomed in when choosing an Itinerary

Map now zooms out to level 12 to view the dive sites on the map better
Map also zooms back in to 16 when returning to the dive shop