### PR TITLE
Web 62 password reset mobile routing

### DIFF
--- a/wetmap/src/components/authentication/Landning/view.tsx
+++ b/wetmap/src/components/authentication/Landning/view.tsx
@@ -1,4 +1,4 @@
-import React, { Dispatch, SetStateAction, useEffect } from 'react';
+import React, { Dispatch, SetStateAction } from 'react';
 import Button from '../../reusables/button';
 import blackManta from '../../../images/blackManta.png';
 import googleIcon from '../../../images/google-color.png';
@@ -15,50 +15,7 @@ type LandingPageProps = {
   socialSignIn: (provider: any) => void
 };
 
-const detectOS = (): string => {
-  const userAgent = navigator.userAgent || navigator.vendor || (window as any).opera;
-
-  // Check for Android
-  if (/android/i.test(userAgent)) {
-    return 'Android';
-  }
-
-  // Check for iOS
-  if (/iPad|iPhone|iPod/.test(userAgent) && !(window as any).MSStream) {
-    return 'iOS';
-  }
-
-  // Check for Windows
-  if (/windows phone/i.test(userAgent)) {
-    return 'Windows Phone';
-  }
-
-  // Check for macOS
-  if (/Macintosh/.test(userAgent)) {
-    return 'macOS';
-  }
-
-  // Check for Windows
-  if (/Win/.test(userAgent)) {
-    return 'Windows';
-  }
-
-  // Check for Linux
-  if (/Linux/.test(userAgent)) {
-    return 'Linux';
-  }
-
-  // Default to "Unknown"
-  return 'Unknown';
-};
-
-
 export default function LandingPageView(props: LandingPageProps) {
-  useEffect(() => {
-    const OS = detectOS();
-    console.log(OS);
-  });
-
   return (
     <div>
       <div className="authenticationPage">

--- a/wetmap/src/components/newModals/passwordUpdate/index.tsx
+++ b/wetmap/src/components/newModals/passwordUpdate/index.tsx
@@ -25,8 +25,6 @@ export default function PasswordUpdate(props: ModalHandleProps) {
     setRunningOn(platform);
   }, []);
 
-  console.log(runningOn);
-
   const onSubmit = async (data: Form) => {
     const response = await performPasswordReset(data.password1);
 

--- a/wetmap/src/components/newModals/passwordUpdate/index.tsx
+++ b/wetmap/src/components/newModals/passwordUpdate/index.tsx
@@ -1,4 +1,4 @@
-import React, { useContext } from 'react';
+import React, { useContext, useEffect, useState } from 'react';
 import { Form } from './form';
 import { toast } from 'react-toastify';
 import PasswordUpdateView from './view';
@@ -7,9 +7,12 @@ import { ModalContext } from '../../reusables/modal/context';
 import { useNavigate } from 'react-router-dom';
 import { ModalHandleProps } from '../../reusables/modal/types';
 import screenData from '../screenData.json';
+import detectOS from './platformDetect';
 
 
 export default function PasswordUpdate(props: ModalHandleProps) {
+  const [runningOn, setRunningOn] = useState<string | null>(null);
+  const [revealRoutes, setRevealRoutes] = useState<boolean>(false);
   const { modalCancel } = useContext(ModalContext);
   const navigate = useNavigate();
 
@@ -17,12 +20,19 @@ export default function PasswordUpdate(props: ModalHandleProps) {
     navigate('/');
   });
 
+  useEffect(() => {
+    const platform = detectOS();
+    setRunningOn(platform);
+  }, []);
+
+  console.log(runningOn);
+
   const onSubmit = async (data: Form) => {
     const response = await performPasswordReset(data.password1);
 
     if (!response.error && response.data) {
       toast.success(screenData.PasswordUpdate.passwordUpdatedSuccessfully);
-      modalCancel();
+      setRevealRoutes(true);
       return;
     }
 
@@ -38,6 +48,8 @@ export default function PasswordUpdate(props: ModalHandleProps) {
     <PasswordUpdateView
       onSubmit={onSubmit}
       onClose={modalCancel}
+      revealRoutes={revealRoutes}
+      runningOn={runningOn}
     />
   );
 };

--- a/wetmap/src/components/newModals/passwordUpdate/platformDetect.ts
+++ b/wetmap/src/components/newModals/passwordUpdate/platformDetect.ts
@@ -1,0 +1,38 @@
+const detectOS = (): string => {
+  const userAgent = navigator.userAgent || navigator.vendor || (window as any).opera;
+
+  // Check for Android
+  if (/android/i.test(userAgent)) {
+    return 'Android';
+  }
+
+  // Check for iOS
+  if (/iPad|iPhone|iPod/.test(userAgent) && !(window as any).MSStream) {
+    return 'iOS';
+  }
+
+  // Check for Windows
+  if (/windows phone/i.test(userAgent)) {
+    return 'Windows Phone';
+  }
+
+  // Check for macOS
+  if (/Macintosh/.test(userAgent)) {
+    return 'macOS';
+  }
+
+  // Check for Windows
+  if (/Win/.test(userAgent)) {
+    return 'Windows';
+  }
+
+  // Check for Linux
+  if (/Linux/.test(userAgent)) {
+    return 'Linux';
+  }
+
+  // Default to "Unknown"
+  return 'Unknown';
+};
+
+export default detectOS;

--- a/wetmap/src/components/newModals/passwordUpdate/view.tsx
+++ b/wetmap/src/components/newModals/passwordUpdate/view.tsx
@@ -9,8 +9,10 @@ import Button from '../../reusables/button';
 import screenData from '../screenData.json';
 
 type PasswordUpdateProps = {
-  onSubmit: (data: Form) => void
-  onClose:  () => void
+  onSubmit:     (data: Form) => void
+  onClose:      () => void
+  revealRoutes: boolean
+  runningOn:    string | null
 };
 
 export default function PasswordUpdateView(props: PasswordUpdateProps) {
@@ -49,18 +51,35 @@ export default function PasswordUpdateView(props: PasswordUpdateProps) {
             />
           </div>
 
-        </div>
-        <div className="cols mx-0">
-          <div className="col-9"></div>
-          <div className="col-3">
-            <Button
-              disabled={isSubmitting}
-              className="btn-md bg-primary"
-              type="submit"
-              iconRight={<Icon name="chevron-right" />}
-            >
-              {screenData.PasswordUpdate.submitButton}
-            </Button>
+          {props.revealRoutes && (
+            <div className="flex-column-between mt-10">
+              <a onClick={props.onClose}>Continue on Desktop?</a>
+              <p className="mb-0">or</p>
+
+              {props.runningOn === 'Android' || props.runningOn === 'iOS'
+                ? <a href="scubaseasons://">Continue on Mobile?</a>
+                : (
+                    <div className="flex-column-between mt-10">
+                      <a href="https://play.google.com/store/apps/details?id=com.freem11.divegomobile"  target="_blank" rel="noreferrer">Available for Android</a>
+                      <a href="https://apps.apple.com/us/app/divego/id6450968950" target="_blank" rel="noreferrer">Available for iOS</a>
+                    </div>
+                  )}
+            </div>
+          )}
+
+
+          <div className="cols mx-0">
+            <div className="col-9"></div>
+            <div className="col-3">
+              <Button
+                disabled={isSubmitting}
+                className="btn-md bg-primary"
+                type="submit"
+                iconRight={<Icon name="chevron-right" />}
+              >
+                {screenData.PasswordUpdate.submitButton}
+              </Button>
+            </div>
           </div>
         </div>
       </form>

--- a/wetmap/src/components/newModals/passwordUpdate/view.tsx
+++ b/wetmap/src/components/newModals/passwordUpdate/view.tsx
@@ -51,6 +51,20 @@ export default function PasswordUpdateView(props: PasswordUpdateProps) {
             />
           </div>
 
+          <div className="cols mx-0">
+            <div className="col-9"></div>
+            <div className="col-3">
+              <Button
+                disabled={isSubmitting}
+                className="btn-md bg-primary"
+                type="submit"
+                iconRight={<Icon name="chevron-right" />}
+              >
+                {screenData.PasswordUpdate.submitButton}
+              </Button>
+            </div>
+          </div>
+
           {props.revealRoutes && (
             <div className="flex-column-between mt-10">
               <a onClick={props.onClose}>Continue on Desktop?</a>
@@ -67,20 +81,6 @@ export default function PasswordUpdateView(props: PasswordUpdateProps) {
             </div>
           )}
 
-
-          <div className="cols mx-0">
-            <div className="col-9"></div>
-            <div className="col-3">
-              <Button
-                disabled={isSubmitting}
-                className="btn-md bg-primary"
-                type="submit"
-                iconRight={<Icon name="chevron-right" />}
-              >
-                {screenData.PasswordUpdate.submitButton}
-              </Button>
-            </div>
-          </div>
         </div>
       </form>
     </div>


### PR DESCRIPTION
Updated Password reset page
now has option for the user based on if the user is on a mobile or desktop device 
Mobile: option to stay on desktop after changing password or go to mobile 
Desktop: option to continue on desktop or offer links to the app stores to get the mobile version (small in app promotion of mobile version basically) 