### PR TITLE
Web 64 correct site submitter header text

### DIFF
--- a/wetmap/src/components/newModals/siteSubmitter/view.tsx
+++ b/wetmap/src/components/newModals/siteSubmitter/view.tsx
@@ -32,7 +32,7 @@ export default function SiteSubmitterView(props: SiteSubmitterProps) {
       <form className="flex-column-between full-height mx-6 mb-6" onSubmit={handleSubmit(props.onSubmit)}>
         <div>
           <div className="d-flex">
-            <h1 className="text-clip">{screenData.PicUploader.header}</h1>
+            <h1 className="text-clip">{screenData.DiveSiteAdd.header}</h1>
           </div>
 
           <div className="stack-4 mb-2">


### PR DESCRIPTION
Changed the site submitter’s header text being imported from the screenData.json file from “Your Sea Creature Sighting” (text for the pic uploader) to “Add a New Dive Site“.
