### PR TITLE
web-73-partner-account-prompt: restyle prompt

### DIFF
--- a/wetmap/src/components/newModals/setting/style.module.scss
+++ b/wetmap/src/components/newModals/setting/style.module.scss
@@ -31,9 +31,8 @@
   }
 
 .upgradeLink {
-    margin-left: 32px;
-    margin-bottom: 4px;
-    font-weight: bold;
+    margin-left: 2.5rem;
+    margin-bottom: 0.25rem;
     color: $primaryBlue;
     cursor: pointer;
     width: max-content;

--- a/wetmap/src/components/newModals/setting/style.module.scss
+++ b/wetmap/src/components/newModals/setting/style.module.scss
@@ -30,5 +30,12 @@
     margin-top: 1rem;
   }
 
-
+.upgradeLink {
+    margin-left: 32px;
+    margin-bottom: 4px;
+    font-weight: bold;
+    color: $primaryBlue;
+    cursor: pointer;
+    width: max-content;
+}
 

--- a/wetmap/src/components/newModals/setting/view.tsx
+++ b/wetmap/src/components/newModals/setting/view.tsx
@@ -36,7 +36,7 @@ export default function SettingsView(props: SettingsProps) {
             { props.profileType === 'Diver Account'
             && (
               <span onClick={props.handlePartnerButton}>
-                <p className="ml-10 mb-1 p-0 text-bold text-primary">{screenData.SettingsPage.notPartnerAccount}</p>
+                <p className={styles.upgradeLink}>{screenData.SettingsPage.notPartnerAccount}</p>
               </span>
             )}
             { props.profileType === 'Partner Account'


### PR DESCRIPTION
Changed color and added pointer cursor to "Request upgrade to Partner Account?" link in the settings modal.

<img width="553" alt="Screenshot 2025-01-14 at 8 15 30 PM" src="https://github.com/user-attachments/assets/fcb9cd9c-58c8-46b6-aaf7-00246a229401" />
