### PR TITLE
web-82 - Heat Points not loading after moving map

### DIFF
--- a/wetmap/src/components/googleMap/marker/markerHeatPoint/index.tsx
+++ b/wetmap/src/components/googleMap/marker/markerHeatPoint/index.tsx
@@ -37,7 +37,7 @@ export function MarkerHeatPoint(props: MarkerHeatPointProps) {
         ref.current.setMap(null);
       }
     };
-  }, [options.data]);
+  }, [props.heatPoints]);
 
   return null;
 }


### PR DESCRIPTION
Heat points data was not being updated because of wrong dependency