### PR TITLE
web-81 - Search Tool: Clear after search

### DIFF
--- a/wetmap/src/components/layout/search/DynamicSelectOptionsMainSearch.ts
+++ b/wetmap/src/components/layout/search/DynamicSelectOptionsMainSearch.ts
@@ -10,7 +10,7 @@ export type OptionAdditionalData = {
 
 export class DynamicSelectOptionsMainSearch extends DynamicSelectOptions {
   static getMoreOptions(search: string) {
-    const placesPromise = getPlacePredictions({ input: search, types: ['locality'] });
+    const placesPromise = getPlacePredictions({ input: search, types: ['geocode'] });
     const diveSitePromise = getSiteNamesThatFit(search);
 
     return Promise.all([placesPromise, diveSitePromise]).then(([places, diveSites]) => {

--- a/wetmap/src/components/layout/search/index.tsx
+++ b/wetmap/src/components/layout/search/index.tsx
@@ -47,6 +47,7 @@ export default function MainSearch() {
   return (
     <div className={style.mainSearch}>
       <DynamicSelect
+        modeSelectedTags="empty"
         labelInValue={true}
         iconLeft={<Icon name="navigation-variant-outline" style={{ scale: '0.7' }} />}
         getMoreOptions={DynamicSelectOptionsMainSearch.getMoreOptions}

--- a/wetmap/src/components/layout/search/index.tsx
+++ b/wetmap/src/components/layout/search/index.tsx
@@ -26,6 +26,7 @@ export default function MainSearch() {
         coordinates = [diveSite.lat, diveSite.lng];
         setSelectedDiveSite(diveSite);
         mapRef?.setZoom(15);
+        mapRef?.panTo({ lat: coordinates[0], lng: coordinates[1] });
         return true;
       });
     }
@@ -33,14 +34,9 @@ export default function MainSearch() {
     if (option?.data?.type === 'place') {
       const response = await getPlaceLocation({ placeId: option?.data.id });
       response?.results?.some((result) => {
-        coordinates = [result.geometry.location.lat(), result.geometry.location.lng()];
-        mapRef?.setZoom(14);
+        mapRef?.fitBounds(result.geometry.viewport);
         return true;
       });
-    }
-
-    if (coordinates.length > 0) {
-      mapRef?.panTo({ lat: coordinates[0], lng: coordinates[1] });
     }
   };
 

--- a/wetmap/src/components/layout/search/index.tsx
+++ b/wetmap/src/components/layout/search/index.tsx
@@ -44,6 +44,7 @@ export default function MainSearch() {
     <div className={style.mainSearch}>
       <DynamicSelect
         modeSelectedTags="empty"
+        triggerOnChangeWhenReselect={true}
         labelInValue={true}
         iconLeft={<Icon name="navigation-variant-outline" style={{ scale: '0.7' }} />}
         getMoreOptions={DynamicSelectOptionsMainSearch.getMoreOptions}

--- a/wetmap/src/components/reusables/select/index.tsx
+++ b/wetmap/src/components/reusables/select/index.tsx
@@ -105,6 +105,11 @@ const defaultProps = {
    */
   modeDropdownOpen: 'onChange' as 'onClick' | 'onChange',
 
+  /**
+   * If true, onChange event is triggered when user selects an already selected option
+   */
+  triggerOnChangeWhenReselect: false as boolean,
+
   onSearch:           (search: string) => {
     // TODO: implement search by static options
   },
@@ -232,7 +237,7 @@ const Select = React.forwardRef<HTMLInputElement, SelectProps>(function Select(_
 
       if (props.maxSelectedOptions === 1) {
         // if user clicks on selected item - do not trigger onChange
-        if (prev.has(key)) {
+        if (!props.triggerOnChangeWhenReselect && prev.has(key)) {
           return prev;
         }
 

--- a/wetmap/src/components/reusables/select/index.tsx
+++ b/wetmap/src/components/reusables/select/index.tsx
@@ -94,8 +94,9 @@ const defaultProps = {
    * In case of multiselect it is a list of selected blocks.
    * - on: selected items appear as tags in the trigger
    * - off: selected items appear as labels in search input
+   * - empty: selected items do not appear neither as tags nor as labels. Search input resets to empty
    */
-  modeSelectedTags: 'off' as 'on' | 'off',
+  modeSelectedTags: 'off' as 'on' | 'off' | 'empty',
 
   /**
    * When to open dropdown
@@ -172,6 +173,10 @@ const Select = React.forwardRef<HTMLInputElement, SelectProps>(function Select(_
       if (selectedOption) {
         searchRef.current.value = selectedOption.label;
       }
+    }
+
+    if (props.modeSelectedTags === 'empty' && searchRef.current) {
+      searchRef.current.value = '';
     }
 
     // prepare data to be passed to onChange(except first render)
@@ -290,6 +295,14 @@ const Select = React.forwardRef<HTMLInputElement, SelectProps>(function Select(_
     });
   }, []);
 
+  const getPlaceholder = () => {
+    if (showSelectedTags) {
+      return value?.size ? undefined : props.placeholder;
+    } else {
+      return searchRef?.current?.value ? undefined : props.placeholder;
+    }
+  };
+
   return (
     <div
       ref={wrapperRef}
@@ -317,7 +330,7 @@ const Select = React.forwardRef<HTMLInputElement, SelectProps>(function Select(_
           onChange={e => onSearch(e.target.value)}
           ref={searchRef}
           type="search"
-          placeholder={!value?.size ? props.placeholder : undefined}
+          placeholder={getPlaceholder()}
         />
 
         <button className="trigger-button">


### PR DESCRIPTION
 - Added new option "empty" to select reusable component.  In this case selected item disappears from search input right after selection.
 - Changed places search type from `locality` to `geocode` because it allows users to search for countries. For example with type `locality` users was unable to find country Cuba, only some cities in US.
