### PR TITLE
Web 105: Fit Bounds for Trips

### DIFF
--- a/wetmap/src/components/itineraryCard/index.tsx
+++ b/wetmap/src/components/itineraryCard/index.tsx
@@ -37,11 +37,35 @@ export default function ItineraryCard({ itinerary, canChangeItinerary }: Itinera
       lngs.push(site.lng);
     });
 
+    const north = Math.max(...lats);
+    const south = Math.min(...lats);
+
+    const maxLng = Math.max(...lngs);
+    const minLng = Math.min(...lngs);
+
+    let east = maxLng;
+    let west = minLng;
+
+    if (maxLng - minLng > 180) {
+      east = minLng;
+      west = maxLng;
+    } else {
+      east = maxLng;
+      west = minLng;
+    }
+
+    const viewPort = {
+      north,
+      south,
+      east,
+      west,
+    };
+
     const moveLat = lats.reduce((acc, curr) => acc + curr, 0) / lats.length;
     const moveLng = lngs.reduce((acc, curr) => acc + curr, 0) / lngs.length;
 
     mapRef?.panTo({ lat: moveLat, lng: moveLng });
-    mapRef?.setZoom(12);
+    mapRef?.fitBounds(viewPort);
     setMapConfig(2);
 
     modalPause();

--- a/wetmap/src/components/itineraryCard/index.tsx
+++ b/wetmap/src/components/itineraryCard/index.tsx
@@ -29,45 +29,13 @@ export default function ItineraryCard({ itinerary, canChangeItinerary }: Itinera
       return; // Exit early if itinerizedDiveSites is undefined or empty
     }
 
-    const lats: number[] = [];
-    const lngs: number[] = [];
-
+    const bounds = new google.maps.LatLngBounds();
     itinerizedDiveSites.forEach((site) => {
-      lats.push(site.lat);
-      lngs.push(site.lng);
+      bounds.extend({ lat: site.lat, lng: site.lng });
     });
 
-    const north = Math.max(...lats);
-    const south = Math.min(...lats);
-
-    const maxLng = Math.max(...lngs);
-    const minLng = Math.min(...lngs);
-
-    let east = maxLng;
-    let west = minLng;
-
-    if (maxLng - minLng > 180) {
-      east = minLng;
-      west = maxLng;
-    } else {
-      east = maxLng;
-      west = minLng;
-    }
-
-    const viewPort = {
-      north,
-      south,
-      east,
-      west,
-    };
-
-    const moveLat = lats.reduce((acc, curr) => acc + curr, 0) / lats.length;
-    const moveLng = lngs.reduce((acc, curr) => acc + curr, 0) / lngs.length;
-
-    mapRef?.panTo({ lat: moveLat, lng: moveLng });
-    mapRef?.fitBounds(viewPort);
+    mapRef?.fitBounds(bounds);
     setMapConfig(2);
-
     modalPause();
   };
 


### PR DESCRIPTION
added `fitBound` to `mapflip` call to pass max and min latitudes and longitudes to it, accounted for east west international date line issue
This results in the map adjusting to the needed scale to fit all dive sites of the trip into view when viewing a trip on the map