### PR TITLE
Web 116 tool tip pencil

### DIFF
--- a/wetmap/src/components/newModals/diveSite/view.tsx
+++ b/wetmap/src/components/newModals/diveSite/view.tsx
@@ -99,6 +99,8 @@ export default function DiveSiteView(props: DiveSiteViewProps) {
                   value={props?.diveSite?.divesitebio || ''}
                   readOnly={!props?.isPartnerAccount}
                   onSave={props?.onDiveSiteBioChange}
+                  tooltipEditText={`Click here to write a bio about ${props?.diveSite?.name}`}
+                  tooltipConfirmText={`Click here to confirm changes to ${props?.diveSite?.name}'s bio`}
                 />
               </div>
             </div>

--- a/wetmap/src/components/newModals/shopModal/view.tsx
+++ b/wetmap/src/components/newModals/shopModal/view.tsx
@@ -62,6 +62,8 @@ export default function ShopModalView(props: ShopModelViewProps) {
                   value={props?.diveShop?.diveshopbio || ''}
                   readOnly={!props?.isPartnerAccount || !props.isMyShop}
                   onSave={props?.handleDiveShopBioChange}
+                  tooltipEditText={`Click here to write a bio about ${props?.diveShop?.orgname}`}
+                  tooltipConfirmText={`Click here to confirm changes to ${props?.diveShop?.orgname}'s bio`}
                 />
               </div>
             </div>

--- a/wetmap/src/components/newModals/userProfile/view.tsx
+++ b/wetmap/src/components/newModals/userProfile/view.tsx
@@ -63,6 +63,8 @@ export default function UserProfileView(props: userProfileViewProps) {
                     readOnly={!props?.isActiveProfile}
                     onSave={props?.handleProfileNameChange}
                     value={props.profile?.UserName}
+                    tooltipEditText="Click here to change your diver name"
+                    tooltipConfirmText="Click here to confirm changes"
                   />
                 </h1>
               </div>
@@ -75,6 +77,8 @@ export default function UserProfileView(props: userProfileViewProps) {
                   onSave={props?.handleProfileBioChange}
                   value={props.profile?.profileBio ?? ''}
                   placeholder={screenData.UserProfile.userDefaultDescription}
+                  tooltipEditText="Click here to write a bio about yourself"
+                  tooltipConfirmText="Click here to confirm changes to your bio"
                 />
               </div>
             </div>

--- a/wetmap/src/components/reusables/plainTextInput/index.tsx
+++ b/wetmap/src/components/reusables/plainTextInput/index.tsx
@@ -3,12 +3,15 @@ import Icon from '../../../icons/Icon';
 import ButtonIcon from '../buttonIcon';
 
 import './style.scss';
+import Tooltip from '../tooltip';
 
 type TextInputProps = InputHTMLAttributes<HTMLInputElement>;
 type CustomInputProps = {
-  onSave: (value: string) => void
-  error?: any
-  value?: string
+  onSave:              (value: string) => void
+  error?:              any
+  value?:              string
+  tooltipEditText?:    string
+  tooltipConfirmText?: string
 };
 
 const PlainTextInput = React.forwardRef<HTMLInputElement, TextInputProps & CustomInputProps>(function PlainTextInput(props: TextInputProps & CustomInputProps, forwardedRef) {
@@ -19,6 +22,34 @@ const PlainTextInput = React.forwardRef<HTMLInputElement, TextInputProps & Custo
   const onKeyDown = (event: React.KeyboardEvent) => {
     if (event.key === 'Enter') {
       event.preventDefault();
+    }
+  };
+
+  const determineTooltipEdit = () => {
+    if (props.tooltipConfirmText) {
+      return (
+        <Tooltip content={props.tooltipEditText}>
+          <Icon name="pencil" fill="darkgrey" />
+        </Tooltip>
+      );
+    } else {
+      return (
+        <Icon name="pencil" fill="darkgrey" />
+      );
+    }
+  };
+
+  const determineTooltipConfirm = () => {
+    if (props.tooltipConfirmText) {
+      return (
+        <Tooltip content={props.tooltipConfirmText}>
+          <Icon name="check-bold" fill="green" />
+        </Tooltip>
+      );
+    } else {
+      return (
+        <Icon name="check-bold" fill="green" />
+      );
     }
   };
 
@@ -42,7 +73,7 @@ const PlainTextInput = React.forwardRef<HTMLInputElement, TextInputProps & Custo
       {!props.readOnly && isEditModeOn && (
         <ButtonIcon
           className="btn-sm"
-          icon={<Icon name="check-bold" fill="green" />}
+          icon={determineTooltipConfirm()}
           onClick={() => {
             setIsEditModeOn(false);
             props.onSave(`${value}`);
@@ -54,7 +85,7 @@ const PlainTextInput = React.forwardRef<HTMLInputElement, TextInputProps & Custo
       {!props.readOnly && !isEditModeOn && (
         <ButtonIcon
           className="btn-sm"
-          icon={<Icon name="pencil" fill="darkgrey" />}
+          icon={determineTooltipEdit()}
           onClick={() => {
             setIsEditModeOn(true);
             setTimeout(function () {


### PR DESCRIPTION
added 2 props to `plantTextInput` and created 2 functions that determine if tool-tip is required or not
props: tooltipEditText and tooltipConfirmText
if either are present then icon renders with tooltip and its text if not then simply the icon renders 
this is facilitated by 2 functions determineTooltipEdit & determineTooltipConfirm
