### PR TITLE
Web-149: Pic Uploader Succesive Photo Submission Issue

### DIFF
--- a/wetmap/src/components/newModals/imageUploadHelpers.js
+++ b/wetmap/src/components/newModals/imageUploadHelpers.js
@@ -1,7 +1,7 @@
 import {
   uploadphoto,
   removePhoto,
-} from "../../cloudflareBucketCalls/cloudflareAWSCalls";
+} from '../../cloudflareBucketCalls/cloudflareAWSCalls';
 
 const handleImageUpload = async (photoInfo) => {
   let imageFile;
@@ -11,8 +11,8 @@ const handleImageUpload = async (photoInfo) => {
     imageFile = photoInfo;
   }
 
-  let extension = imageFile.name.split(".").pop();
-  const fileName = Date.now() + "." + extension;
+  let extension = imageFile.name.split('.').pop();
+  const fileName = Date.now() + '.' + extension;
 
   let uploaded = await uploadImage(imageFile, fileName);
 
@@ -21,11 +21,12 @@ const handleImageUpload = async (photoInfo) => {
 
 const uploadImage = async (file, name) => {
   const data = new FormData();
-  data.append("image", file);
+  data.append('image', file);
   await uploadphoto(file, name);
 };
 
 const clearPreviousImage = async (oldFile) => {
+  console.log('REMOVING', oldFile);
   removePhoto({
     filePath: import.meta.env.VITE_CLOUDFLARE_R2_BUCKET_PATH,
     fileName: `${oldFile}`,

--- a/wetmap/src/components/newModals/imageUploadHelpers.js
+++ b/wetmap/src/components/newModals/imageUploadHelpers.js
@@ -26,7 +26,6 @@ const uploadImage = async (file, name) => {
 };
 
 const clearPreviousImage = async (oldFile) => {
-  console.log('REMOVING', oldFile);
   removePhoto({
     filePath: import.meta.env.VITE_CLOUDFLARE_R2_BUCKET_PATH,
     fileName: `${oldFile}`,

--- a/wetmap/src/components/newModals/picUploader/index.tsx
+++ b/wetmap/src/components/newModals/picUploader/index.tsx
@@ -61,10 +61,10 @@ export default function PicUploader(props: PicUploaderProps) {
       latitude:   selectedDiveSite.lat,
       longitude:  selectedDiveSite.lng,
     });
-
     if (error) {
       toast.error(screenData.PicUploader.uploadError);
     } else {
+      setPhotoFile(null);
       toast.success(screenData.PicUploader.uploadSuccess);
     }
 


### PR DESCRIPTION
added code to clear the `photoFile` at the time of a successful submission
this is so that when users are submitting more than one photo at a time ( a sequence) that the old photo is NOT still being store in `photoFile` 
the reason`photoFile` must be nullified is so that the next submission does NOT remove the previous submission photo from the couldflare bucket 