### PR TITLE
Web-151: Modal Pause Locking Other Modal Issue 

### DIFF
--- a/wetmap/src/components/googleMap/navigation/returnToShopButton/index.tsx
+++ b/wetmap/src/components/googleMap/navigation/returnToShopButton/index.tsx
@@ -5,10 +5,11 @@ import Button from '../../../reusables/button';
 import screenData from '../../../newModals/screenData.json';
 import { SitesArrayContext } from '../../../contexts/sitesArrayContext';
 import { DiveShopContext } from '../../../contexts/diveShopContext';
+import ShopModal from '../../../newModals/shopModal';
 
 export function ReturnToShopButton() {
   const { mapRef, setMapConfig } = useContext(MapContext);
-  const { modalResume } = useContext(ModalContext);
+  const { modalShow } = useContext(ModalContext);
   const { selectedShop } = useContext(DiveShopContext);
   const { setSitesArray } = useContext(SitesArrayContext);
 
@@ -19,10 +20,13 @@ export function ReturnToShopButton() {
       onClick={() => {
         if (selectedShop) {
           mapRef?.panTo({ lat: selectedShop.lat, lng: selectedShop.lng });
+          modalShow(ShopModal, {
+            id:   selectedShop.id,
+            size: 'large',
+          });
         }
         setMapConfig(0);
         setSitesArray([]);
-        modalResume();
       }}
     >
       {screenData.GoogleMap.shopButton}

--- a/wetmap/src/components/itineraryCard/index.tsx
+++ b/wetmap/src/components/itineraryCard/index.tsx
@@ -18,7 +18,7 @@ type ItineraryCardProps = {
 export default function ItineraryCard({ itinerary, canChangeItinerary }: ItineraryCardProps) {
   const { setSitesArray } = useContext(SitesArrayContext);
   const { setMapConfig, mapRef } = useContext(MapContext);
-  const { modalPause, modalShow } = useContext(ModalContext);
+  const { modalShow, modalCancel } = useContext(ModalContext);
 
   const flipMap = async (siteList: number[]) => {
     setSitesArray(siteList);
@@ -37,7 +37,7 @@ export default function ItineraryCard({ itinerary, canChangeItinerary }: Itinera
 
     mapRef?.fitBounds(bounds);
     setMapConfig(2);
-    modalPause();
+    modalCancel();
   };
 
   const handleDeleteButton = async (itinerary: ItineraryItem) => {

--- a/wetmap/src/components/newModals/diveSite/index.tsx
+++ b/wetmap/src/components/newModals/diveSite/index.tsx
@@ -122,6 +122,7 @@ export default function DiveSite(props: DiveSiteProps) {
 
   return (
     <DiveSiteView
+      mapConfig={mapContext.mapConfig}
       onClose={props.onModalCancel}
       openPicUploader={openPicUploader}
       handleImageSelection={handleImageSelection}

--- a/wetmap/src/components/newModals/diveSite/index.tsx
+++ b/wetmap/src/components/newModals/diveSite/index.tsx
@@ -112,6 +112,9 @@ export default function DiveSite(props: DiveSiteProps) {
     if (profile?.UserID === userId) {
       return;
     }
+    if (mapContext.mapConfig === 2) {
+      return;
+    }
     modalShow(UserProfile, {
       keepPreviousModal: true,
       userProfileID:     userId,
@@ -122,7 +125,7 @@ export default function DiveSite(props: DiveSiteProps) {
 
   return (
     <DiveSiteView
-      mapConfig={mapContext.mapConfig}
+      showPicUploaderButton={mapContext.mapConfig !== 2}
       onClose={props.onModalCancel}
       openPicUploader={openPicUploader}
       handleImageSelection={handleImageSelection}

--- a/wetmap/src/components/newModals/diveSite/view.tsx
+++ b/wetmap/src/components/newModals/diveSite/view.tsx
@@ -14,6 +14,7 @@ import Tooltip from '../../reusables/tooltip';
 import ScreenData from '../screenData.json';
 
 type DiveSiteViewProps = {
+  mapConfig:            number
   onClose?:             () => void
   openPicUploader:      () => void
   handleImageSelection: (event: React.ChangeEvent<HTMLInputElement>) => void
@@ -85,12 +86,17 @@ export default function DiveSiteView(props: DiveSiteViewProps) {
                 {'Added by: '}
                 <a
                   href="#"
-                  onClick={() => props.handleProfileSwitch(props?.diveSite?.userid)}
+                  onClick={props.mapConfig === 2
+                    ? () => null
+                    : () => {
+                        props.handleProfileSwitch(props?.diveSite?.userid);
+                      }}
                 >
                   {props?.diveSite?.newusername}
                 </a>
               </div>
             </div>
+
 
             <div className="panel border-none">
               <div className="panel-body">
@@ -110,11 +116,15 @@ export default function DiveSiteView(props: DiveSiteViewProps) {
         <div className="panel-header">
           <h3>{screenData.DiveSite.drawerHeader}</h3>
           <div className={style.addPictureButton}>
-            <Button className="btn-lg" onClick={props.openPicUploader}>
-              <span className="hide-sm">
-                {screenData.DiveSite.addSightingButton}
-              </span>
-            </Button>
+            {props.mapConfig !== 2
+            && (
+              <Button className="btn-lg" onClick={props.openPicUploader}>
+                <span className="hide-sm">
+                  {screenData.DiveSite.addSightingButton}
+                </span>
+              </Button>
+            ) }
+
           </div>
         </div>
         <div className="panel-body">

--- a/wetmap/src/components/newModals/diveSite/view.tsx
+++ b/wetmap/src/components/newModals/diveSite/view.tsx
@@ -14,16 +14,16 @@ import Tooltip from '../../reusables/tooltip';
 import ScreenData from '../screenData.json';
 
 type DiveSiteViewProps = {
-  mapConfig:            number
-  onClose?:             () => void
-  openPicUploader:      () => void
-  handleImageSelection: (event: React.ChangeEvent<HTMLInputElement>) => void
-  handleProfileSwitch:  (username: string) => Promise<void>
-  onDiveSiteBioChange:  (newValue: string) => void
-  diveSite:             DiveSiteWithUserName | null
-  diveSitePics:         PhotosGroupedByDate[] | null
-  isPartnerAccount:     boolean
-  headerPictureUrl:     string | null
+  showPicUploaderButton: boolean
+  onClose?:              () => void
+  openPicUploader:       () => void
+  handleImageSelection:  (event: React.ChangeEvent<HTMLInputElement>) => void
+  handleProfileSwitch:   (username: string) => Promise<void>
+  onDiveSiteBioChange:   (newValue: string) => void
+  diveSite:              DiveSiteWithUserName | null
+  diveSitePics:          PhotosGroupedByDate[] | null
+  isPartnerAccount:      boolean
+  headerPictureUrl:      string | null
 };
 
 
@@ -86,11 +86,7 @@ export default function DiveSiteView(props: DiveSiteViewProps) {
                 {'Added by: '}
                 <a
                   href="#"
-                  onClick={props.mapConfig === 2
-                    ? () => null
-                    : () => {
-                        props.handleProfileSwitch(props?.diveSite?.userid);
-                      }}
+                  onClick={() => props.handleProfileSwitch(props?.diveSite?.userid)}
                 >
                   {props?.diveSite?.newusername}
                 </a>
@@ -116,7 +112,7 @@ export default function DiveSiteView(props: DiveSiteViewProps) {
         <div className="panel-header">
           <h3>{screenData.DiveSite.drawerHeader}</h3>
           <div className={style.addPictureButton}>
-            {props.mapConfig !== 2
+            {props.showPicUploaderButton
             && (
               <Button className="btn-lg" onClick={props.openPicUploader}>
                 <span className="hide-sm">

--- a/wetmap/src/components/reusables/fullScreenImage/fullScreenImage.tsx
+++ b/wetmap/src/components/reusables/fullScreenImage/fullScreenImage.tsx
@@ -2,13 +2,13 @@ import React from 'react';
 import style from './fullScreenImage.module.scss';
 import ButtonIcon from '../buttonIcon';
 import Icon from '../../../icons/Icon';
+import { ModalHandleProps } from '../modal/types';
 
 type FullScreenImageViewProps = {
   src:           string
-  onModalCancel: () => void
 };
 
-const FullScreenImage = (props: FullScreenImageViewProps) => {
+const FullScreenImage = (props: FullScreenImageViewProps & Partial<ModalHandleProps>) => {
   return (
     <>
       <div

--- a/wetmap/src/components/reusables/modal/contextProvider.tsx
+++ b/wetmap/src/components/reusables/modal/contextProvider.tsx
@@ -14,6 +14,10 @@ const ModalContextProvider = ({ children }: any) => {
   const modalShow: ModalShow = (component, options) => {
     const newModalWindow = new ModalWindow(component, options);
 
+    if (paused) {
+      return;
+    }
+
     if (newModalWindow.name === currentModalName) {
       return;
     }

--- a/wetmap/src/components/reusables/modal/contextProvider.tsx
+++ b/wetmap/src/components/reusables/modal/contextProvider.tsx
@@ -15,6 +15,7 @@ const ModalContextProvider = ({ children }: any) => {
     const newModalWindow = new ModalWindow(component, options);
 
     if (paused) {
+      // stop gap measure, need to refactor to allow other modals to open while one is paused
       return;
     }
 

--- a/wetmap/src/components/reusables/seaLifeImageCard/index.tsx
+++ b/wetmap/src/components/reusables/seaLifeImageCard/index.tsx
@@ -27,6 +27,7 @@ export default function SeaLifeImageCard(props: { pic: PhotoWithLikesAndComments
   const { mapRef } = useContext(MapContext);
   const { modalShow } = useContext(ModalContext);
   const photoName = pic.photoFile.split('/').pop();
+  const mapContext = useContext(MapContext);
 
   const handleProfileSwitch = async (e: React.MouseEvent<HTMLHeadingElement, MouseEvent>, userId: string) => {
     e.stopPropagation();
@@ -89,6 +90,7 @@ export default function SeaLifeImageCard(props: { pic: PhotoWithLikesAndComments
   return (
     <SeaLifeImageCardView
       pic={pic}
+      mapConfig={mapContext.mapConfig}
       handleModalOpen={handleModalOpen}
       handleLike={handleLike}
       handleCommentModal={handleCommentModal}

--- a/wetmap/src/components/reusables/seaLifeImageCard/index.tsx
+++ b/wetmap/src/components/reusables/seaLifeImageCard/index.tsx
@@ -35,6 +35,9 @@ export default function SeaLifeImageCard(props: { pic: PhotoWithLikesAndComments
     if (profile?.UserID === userId) {
       return;
     }
+    if (mapContext.mapConfig === 2) {
+      return;
+    }
     modalShow(UserProfile, {
       keepPreviousModal: true,
       userProfileID:     userId,
@@ -90,7 +93,6 @@ export default function SeaLifeImageCard(props: { pic: PhotoWithLikesAndComments
   return (
     <SeaLifeImageCardView
       pic={pic}
-      mapConfig={mapContext.mapConfig}
       handleModalOpen={handleModalOpen}
       handleLike={handleLike}
       handleCommentModal={handleCommentModal}

--- a/wetmap/src/components/reusables/seaLifeImageCard/view.tsx
+++ b/wetmap/src/components/reusables/seaLifeImageCard/view.tsx
@@ -11,7 +11,6 @@ import BlurryImage from '../blurryImage';
 
 type SeaLifeImageCardViewProps = {
   pic:                 PhotoWithLikesAndComments
-  mapConfig:           number
   handleModalOpen:     () => void
   handleLike:          (e: React.MouseEvent<HTMLHeadingElement, MouseEvent>) => Promise<void>
   handleProfileSwitch: (e: React.MouseEvent<HTMLHeadingElement, MouseEvent>, username: string) => Promise<void>
@@ -51,7 +50,7 @@ export default function SeaLifeImageCardView(props: SeaLifeImageCardViewProps) {
           ? (
               <h4
                 className={style.userLabel}
-                onClick={props.mapConfig === 2 ? () => null : e => props.handleProfileSwitch(e, props.pic.UserID)}
+                onClick={e => props.handleProfileSwitch(e, props.pic.UserID)}
               >
                 Added by:
                 {' '}

--- a/wetmap/src/components/reusables/seaLifeImageCard/view.tsx
+++ b/wetmap/src/components/reusables/seaLifeImageCard/view.tsx
@@ -11,6 +11,7 @@ import BlurryImage from '../blurryImage';
 
 type SeaLifeImageCardViewProps = {
   pic:                 PhotoWithLikesAndComments
+  mapConfig:           number
   handleModalOpen:     () => void
   handleLike:          (e: React.MouseEvent<HTMLHeadingElement, MouseEvent>) => Promise<void>
   handleProfileSwitch: (e: React.MouseEvent<HTMLHeadingElement, MouseEvent>, username: string) => Promise<void>
@@ -50,7 +51,7 @@ export default function SeaLifeImageCardView(props: SeaLifeImageCardViewProps) {
           ? (
               <h4
                 className={style.userLabel}
-                onClick={e => props.handleProfileSwitch(e, props.pic.UserID)}
+                onClick={props.mapConfig === 2 ? () => null : e => props.handleProfileSwitch(e, props.pic.UserID)}
               >
                 Added by:
                 {' '}


### PR DESCRIPTION
removed modal pause when moving to view trips on the map and instead use the mapConfig and selectedDiveShop to return the user to the correct dive shop page when finished viewing a trip

when viewing a dive site and the mapConfig is set to 2 the ability to click on the tags to move to see a user profile are disabled and the 'add sighting' button is not shown 

in other words while viewing trips users can open the dive site to see the details of the sites on the trip but cannot proceed further

This also resolved the issue of the modal locking due to modal pause 