### PR TITLE
web-176b-dive-site-date-label: 

### DIFF
--- a/wetmap/src/helpers/readableDate.ts
+++ b/wetmap/src/helpers/readableDate.ts
@@ -3,6 +3,6 @@ export default function readableDate(date: string) {
     month: 'short',
     day:   'numeric',
     year:  'numeric',
-  }).format(new Date(date));
+  }).format(new Date(date + 'T00:00:00'));
   return formattedDate;
 }


### PR DESCRIPTION
updated produced date with zeroed out timeszone to eliminate issue