### PR TITLE
web-207-FixSiteSelectorMapReturnBug

### DIFF
--- a/wetmap/src/components/googleMap/navigation/returnToCreateTripButton/index.tsx
+++ b/wetmap/src/components/googleMap/navigation/returnToCreateTripButton/index.tsx
@@ -3,22 +3,16 @@ import { MapContext } from '../../mapContext';
 import { ModalContext } from '../../../reusables/modal/context';
 import Button from '../../../reusables/button';
 import screenData from '../../../newModals/screenData.json';
-import { DiveShopContext } from '../../../contexts/diveShopContext';
 
 export function ReturnToCreateTripButton() {
-  const { mapRef, setMapConfig } = useContext(MapContext);
+  const { setMapConfig } = useContext(MapContext);
   const { modalResume } = useContext(ModalContext);
-  const { selectedShop } = useContext(DiveShopContext);
 
   return (
     <Button
       className="btn-md bg-primary"
       type="button"
       onClick={() => {
-        // should this onClick be the same as the returnToShopButton??
-        if (selectedShop) {
-          mapRef?.panTo({ lat: selectedShop.lat, lng: selectedShop.lng });
-        }
         setMapConfig(0);
         modalResume();
       }}


### PR DESCRIPTION
Removed code that was causing the map to move when the 'set sites' button was pressed when using the site selector to build a dive trip.