### PR TITLE
ScottDavis08-Address-divide-errors-scss

### DIFF
--- a/wetmap/src/styles/variables.scss
+++ b/wetmap/src/styles/variables.scss
@@ -46,7 +46,20 @@ $transparent-background-color: rgba(255, 255, 255, 0.2);
     align-self: self-start;
 }
 
-// Load default ones from spectre.css
+//TODO: On future versions, check if Spectre has fixed the divide by error, and remove these overrides.
+// Define control sizes and related variables needed for padding calculations
+$control-size: 1.8rem !default;
+$control-size-sm: 1.4rem !default;
+$line-height: 1.2rem !default;
+$border-width: 0.05rem !default;
+
+// Override Spectre.css variables to fix Sass deprecation warnings
+$control-padding-y: calc(($control-size - $line-height) / 2) - $border-width !default;
+$control-padding-y-sm: calc(($control-size-sm - $line-height) / 2) - $border-width !default;
+$control-padding-y-lg: calc(($control-size-lg - $line-height) / 2) - $border-width !default;
+
+
+// Load default ones from spectre.css AFTER our overrides
 @import 'spectre.css/src/variables';
 
 $responsive-breakpoints: (


### PR DESCRIPTION
Spectre in the current version throws regular errors due to the use of / for divide.

This PR overrides those variables with a fixed use of division and adds a TODO note to check when Spectre gets updated if the override is still necessary.