### PR TITLE
Image switchover

### DIFF
--- a/wetmap/src/components/boundaryAnimals/animalItem/index.tsx
+++ b/wetmap/src/components/boundaryAnimals/animalItem/index.tsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import { Animal } from '../../../entities/photos';
-import getPhotoPublicUrl from '../../../helpers/getPhotoPublicUrl';
 import SidebarCard from '../../reusables/sidebarCard';
+import { IMAGE_SIZE } from '../../../entities/image';
+import getImagePublicUrl from '../../../helpers/getImagePublicUrl';
 
 type AnimalItemProps = {
   animal:        Animal
@@ -9,7 +10,7 @@ type AnimalItemProps = {
 };
 
 export function AnimalItem(props: AnimalItemProps) {
-  const imageUrl = getPhotoPublicUrl(props.animal.photofile);
+  const imageUrl = getImagePublicUrl(props.animal.image, IMAGE_SIZE.LG);
   if (!imageUrl) {
     return null;
   }

--- a/wetmap/src/entities/image.ts
+++ b/wetmap/src/entities/image.ts
@@ -1,0 +1,15 @@
+export type Image = {
+  file_name:     string
+  public_domain: string
+  sm:            string
+  md:            string
+  lg:            string
+  xl:            string
+};
+
+export enum IMAGE_SIZE {
+  SM = 'sm',  // width 240px
+  MD = 'md',  // width 480px
+  LG = 'lg',  // width 960px
+  XL = 'xl',  // width 1920px
+}

--- a/wetmap/src/entities/photos.ts
+++ b/wetmap/src/entities/photos.ts
@@ -1,3 +1,5 @@
+import { Image } from './image';
+
 export type PhotoWithLikesAndComments = {
   id:           number
   created_at:   string
@@ -36,8 +38,8 @@ export type Photo = {
 
 export type Animal = {
   label:      string
-  photofile:  string
   times_seen: number
+  image:      Image
 };
 
 export type HistogramData = {

--- a/wetmap/src/helpers/getImagePublicUrl.ts
+++ b/wetmap/src/helpers/getImagePublicUrl.ts
@@ -1,0 +1,29 @@
+import { Image, IMAGE_SIZE } from '../entities/image';
+
+/**
+ * Returns public URL for image
+ * @param image
+ * @param size
+ * @param fallbacks
+ * @returns
+ */
+export default function getImagePublicUrl(image: Image | null, size: IMAGE_SIZE, ...fallbacks: any[]) {
+  const fallback = fallbacks.find(Boolean) || '';
+
+  if (!image) {
+    return fallback;
+  }
+
+  if (image[size] && image.public_domain) {
+    return image.public_domain + '/' + image[size];
+  }
+
+  // If requested size is not available return original image uploaded by user
+  if (image.file_name) {
+    const fileName = image.file_name.split('/').pop();
+    if (fileName) {
+      return import.meta.env.VITE_CLOUDFLARE_R2_BUCKET_PATH + `${fileName}`;
+    }
+  }
+  return fallback;
+}

--- a/wetmap/src/supabaseCalls/photoSupabaseCalls.ts
+++ b/wetmap/src/supabaseCalls/photoSupabaseCalls.ts
@@ -121,10 +121,27 @@ export const getAnimalsInBubble = async (bubble: GPSBubble, filter?: Partial<Pho
     return [];
   }
 
+  const result = [] as Animal[];
   if (data) {
-    return data as Animal[];
+    data.forEach((item: any) => {
+      const animal: Animal = {
+        label:      item.label,
+        times_seen: item.times_seen,
+        image:      {
+          file_name:     item.photofile,
+          public_domain: '',
+          sm:            item.sm,
+          md:            item.md,
+          lg:            item.lg,
+          xl:            item.xl,
+        },
+      };
+
+      result.push(animal);
+    });
   }
-  return [];
+
+  return result;
 };
 
 // not in use - remove

--- a/wetmap/src/supabaseCalls/photoSupabaseCalls.ts
+++ b/wetmap/src/supabaseCalls/photoSupabaseCalls.ts
@@ -129,7 +129,7 @@ export const getAnimalsInBubble = async (bubble: GPSBubble, filter?: Partial<Pho
         times_seen: item.times_seen,
         image:      {
           file_name:     item.photofile,
-          public_domain: '',
+          public_domain: item.public_domain,
           sm:            item.sm,
           md:            item.md,
           lg:            item.lg,


### PR DESCRIPTION
Begining of the work to use processed variants of the images
- Modified `getAnimalsInBubble` function to return nested `Image`  object instead of flat object
- Added function `getImagePublicUrl` - util function that should be used in all places where we need to render processed image. Currently is being used in one place(`AnimalItem` component) as an example
- Added type `Image` and enum `IMAGE_SIZE` 